### PR TITLE
Consider consolidate apt steps

### DIFF
--- a/apt-setup.sh
+++ b/apt-setup.sh
@@ -5,7 +5,9 @@ apt-get install -qqy \
 	build-essential \
 	libabsl-dev \
 	libboost-all-dev \
+        libboost-log1.74.0 \
 	libgrpc++-dev \
+        libgrpc++1 \
 	libprotobuf-dev \
 	pkg-config \
 	ninja-build \


### PR DESCRIPTION
Consider merging `sudo apt install -qqy libgrpc++1 libboost-log1.74.0` step into existing `apt-setup.sh` file to complete package dependency installation in one step.

Note: We don't want this if automated uses of setup.sh by the GitHub action should not require these two new packages for some reason.

PR made in response to comments to https://github.com/viamrobotics/module-example-cpp/pull/4/